### PR TITLE
Remove null value features

### DIFF
--- a/app/api/tiles/[study_slug]/[scenario_slug]/[metrics_field]/[z]/[x]/[y]/route.ts
+++ b/app/api/tiles/[study_slug]/[scenario_slug]/[metrics_field]/[z]/[x]/[y]/route.ts
@@ -157,7 +157,9 @@ class Tile {
           )
           AND
           ((t.study_slug = ${this.study_slug} AND m.scenario_slug IS NULL AND ${this.scenario_slug} = 'baseline') OR 
-          (t.study_slug = ${this.study_slug} AND m.scenario_slug = ${this.scenario_slug})) 
+          (t.study_slug = ${this.study_slug} AND m.scenario_slug = ${this.scenario_slug}))
+          AND
+          m.data->${this.metrics_field}->>'value' IS NOT NULL -- remove features with NULL value
       )
       SELECT
         ST_AsMVT(mvtgeom.*)


### PR DESCRIPTION
## Remove all features without values

In some cases data is present for some features but missing for others. In those cases we do not want to show the underlying geometry but rather strip it from the tile altogether. A simple WHERE clause on the query removes those features that do not have associated values in the metrics table. 
Before:
![Screenshot 2024-05-09 at 10 42 45 AM](https://github.com/developmentseed/tecnico-energy-app/assets/31222040/8471fadf-ed49-4308-a552-e6022570ad6a)
After:
![Screenshot 2024-05-09 at 10 49 19 AM](https://github.com/developmentseed/tecnico-energy-app/assets/31222040/3d5a7cb0-40ab-491d-8ba5-8007074973f0)
