### PR TITLE
Add Github Actions to deploy separate preview branch

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,7 +6,6 @@ env:
   VERCEL_ACCESS_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
   VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-  VERCEL_TEAM_ID: ${{ vars.VERCEL_ORG_ID }}
 
 on:
   pull_request:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,265 @@
+# https://vercel.com/guides/how-can-i-use-github-actions-with-vercel
+
+name: Preview Environment
+
+env:
+  VERCEL_ACCESS_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+  VERCEL_TEAM_ID: ${{ vars.VERCEL_ORG_ID }}
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  deploy:
+    if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Instruct github to checkout actual branch, not a detached head
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install Vercel CLI
+        run: pnpm install --global vercel@latest
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Set dotenv path
+        env:
+          VERCEL_ENV_FILE: .vercel/.env.preview.local
+        run: echo "VERCEL_ENV_FILE=$VERCEL_ENV_FILE" >> "$GITHUB_ENV"
+
+      - name: Mask secret .env values
+        run: |
+          for var in POSTGRES_PASSWORD; do
+            echo "Marking $var as secret"
+            echo "::add-mask::$(grep "^${var}=" ${{ env.VERCEL_ENV_FILE }} | cut -d '=' -f2- | tr -d '"')"
+          done;
+
+      - name: Read Vercel environment information
+        uses: falti/dotenv-action@v1.1.2
+        id: original-dotenv
+        with:
+          path: ${{ env.VERCEL_ENV_FILE }}
+          log-variables: true
+
+      - name: Update Vercel environment information with new DB name
+        run: |
+          DB_NAME=PR_$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+          sed -i "s/${{ steps.original-dotenv.outputs.POSTGRES_DATABASE }}/${DB_NAME}/g" ${{ env.VERCEL_ENV_FILE }}
+        shell: bash
+
+      - name: Read updated Vercel environment information
+        uses: falti/dotenv-action@v1.1.2
+        id: updated-dotenv
+        with:
+          path: ${{ env.VERCEL_ENV_FILE }}
+          log-variables: true
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+
+      - name: Maybe create database
+        run: |
+          if ! psql -lqt | cut -d \| -f 1 | grep -qw ${{ steps.updated-dotenv.outputs.POSTGRES_DATABASE }}; then
+            createdb ${{ steps.updated-dotenv.outputs.POSTGRES_DATABASE }}
+          else
+            echo "Database ${{ steps.updated-dotenv.outputs.POSTGRES_DATABASE }} already exists, skipping creation."
+          fi
+        env:
+          PGHOST: ${{ steps.original-dotenv.outputs.POSTGRES_HOST }}
+          PGUSER: ${{ steps.original-dotenv.outputs.POSTGRES_USER }}
+          PGPASSWORD: ${{ steps.original-dotenv.outputs.POSTGRES_PASSWORD }}
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build project artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy project artifacts to Vercel
+        id: deploy
+        run: |
+          echo URL=$(vercel deploy \
+            --prebuilt \
+            --token=${{ secrets.VERCEL_TOKEN }} \
+            --env POSTGRES_PRISMA_URL='${{ steps.updated-dotenv.outputs.POSTGRES_PRISMA_URL }}' \
+            --env POSTGRES_URL_NON_POOLING='${{ steps.updated-dotenv.outputs.POSTGRES_URL_NON_POOLING }}' \
+          ) >> $GITHUB_OUTPUT
+
+      - run: echo "${{ steps.deploy.outputs.URL }}"
+
+      - name: Get current time
+        uses: gerred/actions/current-time@master
+        if: ${{ github.event.pull_request.number }}
+        id: current-time
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        if: ${{ github.event.pull_request.number }}
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Latest commit deployed to
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: ${{ github.event.pull_request.number }}
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 Latest commit deployed to ${{ steps.deploy.outputs.URL }}
+
+            * Date: `${{ steps.current-time.outputs.time }}`
+            * Commit: ${{ github.sha }} (merging ${{ github.event.pull_request.head.sha }} into ${{ github.event.pull_request.base.sha }})
+
+          edit-mode: replace
+
+  destroy:
+    if: ${{ github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install Vercel CLI
+        run: pnpm install --global vercel@latest
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Set dotenv path
+        env:
+          VERCEL_ENV_FILE: .vercel/.env.preview.local
+        run: echo "VERCEL_ENV_FILE=$VERCEL_ENV_FILE" >> "$GITHUB_ENV"
+
+      - name: Mask secret .env values
+        run: |
+          for var in POSTGRES_PASSWORD; do
+            echo "Marking $var as secret"
+            echo "::add-mask::$(grep "^${var}=" ${{ env.VERCEL_ENV_FILE }} | cut -d '=' -f2- | tr -d '"')"
+          done;
+
+      - name: Load Vercel environment information into runtime environment
+        uses: falti/dotenv-action@v1.1.2
+        id: original-dotenv
+        with:
+          path: ${{ env.VERCEL_ENV_FILE }}
+          log-variables: true
+
+      - name: Get DB name
+        id: db-name
+        run: |
+          echo NAME=PR_$(echo "$GITHUB_REF" | awk -F / '{print $3}') >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+
+      - name: Close database connections
+        run: |
+          psql ${{ steps.original-dotenv.outputs.POSTGRES_DATABASE }} -c "
+            SELECT pg_terminate_backend(pg_stat_activity.pid)
+            FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '${{ steps.db-name.outputs.NAME }}'
+            AND pid <> pg_backend_pid();"
+        env:
+          PGHOST: ${{ steps.original-dotenv.outputs.POSTGRES_HOST }}
+          PGUSER: ${{ steps.original-dotenv.outputs.POSTGRES_USER }}
+          PGPASSWORD: ${{ steps.original-dotenv.outputs.POSTGRES_PASSWORD }}
+
+      - name: Drop database
+        run: |
+          dropdb ${{ steps.db-name.outputs.NAME }}
+        env:
+          PGHOST: ${{ steps.original-dotenv.outputs.POSTGRES_HOST }}
+          PGUSER: ${{ steps.original-dotenv.outputs.POSTGRES_USER }}
+          PGPASSWORD: ${{ steps.original-dotenv.outputs.POSTGRES_PASSWORD }}
+
+      - name: Get current time
+        uses: gerred/actions/current-time@master
+        if: ${{ github.event.pull_request.number }}
+        id: current-time
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        if: ${{ github.event.pull_request.number }}
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Latest commit deployed to
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: ${{ github.event.pull_request.number }}
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ---
+            🧹 Deleted DB 
+
+            * Date: `${{ steps.current-time.outputs.time }}`
+          edit-mode: append

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["postgresqlExtensions"]
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 // Auto generate an ERD diagram for the database. 


### PR DESCRIPTION
This feature creates a separate database and uses that for the PR preview, allowing for end-users to preview the data before deploying to production. A bot places a comment on the PR to allow the users to easily find the PR preview. To allow for this feature, we disabled PR previews on non-production branches within Vercel.  When a PR is closed (or merged), the preview DB is dropped.