### PR TITLE
Rm need for front matter from MDX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,8 @@ The study spreadsheet must contain the following worksheets. Column/key names ar
 
 ### Study Details Markdown
 
-- the `front matter` contained at the top of each mdx file needs to be enclosed in `---`
-- each file needs to contain the `title`, `description`, and `type: Doc` fields in the `front matter`. There is only one type and it needs to be `Doc`.
-- it is possible but optional to include MDX content in html tags like `<img/>`
-- The markdown content needs to follow standard markdown syntax as described
-  in _[Markdown Guide](https://www.markdownguide.org/basic-syntax/)_
+- it is possible to include MDX content in html tags (e.g. `<img src="..." width="..." alt="..." />`)
+- The markdown content needs to follow standard markdown syntax as described in _[Markdown Guide](https://www.markdownguide.org/basic-syntax/)_
 
 ## Development
 

--- a/app/explore/[slug]/details/page.tsx
+++ b/app/explore/[slug]/details/page.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image"
-import chevron from "../../../../public/icons/chevron-left.svg"
 import Link from "next/link"
 import { allDocs } from "contentlayer/generated"
 import { notFound } from "next/navigation"
-import { Mdx } from "../../../../components/mdx-components"
+import { getStudy } from "@/app/lib/data"
+import chevron from "@/public/icons/chevron-left.svg"
+import { Mdx } from "@/components/mdx-components"
 
 async function getDocFromParams(slug: string) {
   const doc = allDocs.find(doc => doc.slugAsParams === slug)
@@ -17,7 +18,8 @@ const StudyDetails: React.FC = async ({
 }: {
   params: { slug: string }
 }) => {
-  const doc = await getDocFromParams(params.slug)
+  const [doc, study] = await Promise.all([getDocFromParams(params.slug), getStudy(params.slug)])
+  if (!study) notFound()
 
   return (
     <div className="min-h-screen h-full w-full bg-slate-100 p-12">
@@ -27,7 +29,7 @@ const StudyDetails: React.FC = async ({
             <Image src={chevron} alt="chevron" width={22} height={22} />
           </Link>
         </div>
-        <div>{`About ${doc?.title}`}</div>
+        <div>{`About ${study.name}`}</div>
       </div>
       <div className="ml-12">
         <Mdx

--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -18,15 +18,9 @@ const computedFields = {
 
 export const Doc = defineDocumentType(() => ({
   name: "Doc",
-  filePathPattern: "data/**/*.mdx",
+  filePathPattern: "**/*.mdx",
   contentType: "mdx",
-  fields: {
-    title: {
-      type: "string",
-      required: true,
-    },
-    description: { type: "string" },
-  },
+  fields: {},
   computedFields,
 }))
 

--- a/data/lisbon-building-study.mdx
+++ b/data/lisbon-building-study.mdx
@@ -1,9 +1,3 @@
----
-title: Lisbon Building Study
-description: A study of the buildings in Lisbon
-type: Doc
----
-
 <br />
 <img
   src={"https://plus.unsplash.com/premium_photo-1677653126817-a05d8c6ddb9d"}

--- a/data/municipal-study.mdx
+++ b/data/municipal-study.mdx
@@ -1,9 +1,3 @@
----
-title: Municipal Study
-description: A study of municipalities
-type: Doc
----
-
 <br />
 <img
   src={"https://images.unsplash.com/photo-1524928872228-9b284de342b3"}


### PR DESCRIPTION
This PR removes the need for frontmatter from our MDX, instead relying on the metadata provided in the XLSX files.  This reduces redundant and ambiguous data input.